### PR TITLE
Fix for #21 Mac launcher

### DIFF
--- a/Content/RunOnMac.command
+++ b/Content/RunOnMac.command
@@ -1,4 +1,9 @@
 #!/bin/bash -x
 cd "$(dirname "$0")"
 export DYLD_FALLBACK_LIBRARY_PATH="/Library/Frameworks/Mono.framework/Versions/Current/lib:/lib:/usr/lib"
-exec mono "Desktop Ponies.exe" "$@"
+
+if hash mono32 2>/dev/null; then
+   exec mono32 "Desktop Ponies.exe" "$@"
+else
+   exec mono "Desktop Ponies.exe" "$@"
+fi


### PR DESCRIPTION
I used this method: https://stackoverflow.com/a/677212/98029

I have an old MacBook that won't upgrade beyond El Capitan (10.11) and it worked in it.