### PR TITLE
Fixed app crash on computers without playback devices

### DIFF
--- a/Desktop Ponies/DesktopPonies/PonyAnimator.vb
+++ b/Desktop Ponies/DesktopPonies/PonyAnimator.vb
@@ -283,8 +283,17 @@ Public MustInherit Class PonyAnimator
                 output.Play()
             Catch ex As Exception
                 ' Swallow any exception here. The sound file may be missing, inaccessible, not a playable format, etc.
-                If sound IsNot Nothing Then sound.Dispose()
-                If output IsNot Nothing Then output.Dispose()
+                If sound IsNot Nothing Then
+                    sound.Dispose()
+                    output = Nothing
+                    sound = Nothing
+                End If
+                If output IsNot Nothing Then
+                    output.Dispose()
+                    output = Nothing
+                    sound = Nothing
+                End If
+
             Finally
                 If sound IsNot Nothing Then
                     If sound.TotalTime > TimeSpan.FromDays(1) Then

--- a/Desktop Ponies/DesktopPonies/PonyAnimator.vb
+++ b/Desktop Ponies/DesktopPonies/PonyAnimator.vb
@@ -285,13 +285,11 @@ Public MustInherit Class PonyAnimator
                 ' Swallow any exception here. The sound file may be missing, inaccessible, not a playable format, etc.
                 If sound IsNot Nothing Then
                     sound.Dispose()
-                    output = Nothing
                     sound = Nothing
                 End If
                 If output IsNot Nothing Then
                     output.Dispose()
                     output = Nothing
-                    sound = Nothing
                 End If
 
             Finally


### PR DESCRIPTION
PonyAnimator.vb:284
Output and sound object can be created, but exception may also occur during their initialization. For example 'BadDeviceId calling waveOutOpen' when there is no playback devices on the PC. Created objects should be set to Nothing, either they will be added to 'activeSounds' list and the application will fall in 'CleanupSounds' method.